### PR TITLE
Set the `AdoptDetailInfoCell.infoLabel` compression resistance priori…

### DIFF
--- a/FindYourOnlysClone/FindYourOnlysClone/Adopt List/UI/View/AdoptDetailInfoCell.swift
+++ b/FindYourOnlysClone/FindYourOnlysClone/Adopt List/UI/View/AdoptDetailInfoCell.swift
@@ -50,5 +50,7 @@ final class AdoptDetailInfoCell: UICollectionViewCell {
             infoLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
             infoLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10)
         ])
+        
+        infoLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
 }


### PR DESCRIPTION
…ty to be `default low` to avoid `infoTitleLabel` be shrink when content is too long