### PR TITLE
`AdoptListViewController` does not cancel image loading task on `didE…

### DIFF
--- a/FindYourOnlysClone/FindYourOnlysClone/Adopt List/UI/Controller/AdoptListCellViewController.swift
+++ b/FindYourOnlysClone/FindYourOnlysClone/Adopt List/UI/Controller/AdoptListCellViewController.swift
@@ -28,7 +28,7 @@ final class AdoptListCellViewController {
         cell?.retryImageLoadHandler = viewModel.loadPetImageData
         cell?.prepareForReuseHandler = { [weak self, weak cell] in
             cell?.petImageView.image = nil
-            self?.releaseBindings()
+            self?.cancelTask()
         }
         
         return cell!

--- a/FindYourOnlysClone/FindYourOnlysClone/Adopt List/UI/Controller/AdoptListViewController.swift
+++ b/FindYourOnlysClone/FindYourOnlysClone/Adopt List/UI/Controller/AdoptListViewController.swift
@@ -173,10 +173,6 @@ extension AdoptListViewController {
         requestImageData(at: indexPath)
     }
     
-    override func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        cancelTask(forItemAt: indexPath)
-    }
-    
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         cellController(at: indexPath)?.didSelect()
     }

--- a/FindYourOnlysClone/FindYourOnlysCloneTests/Adopt List/UI/Helpers/AdoptListViewController+TestHelpers.swift
+++ b/FindYourOnlysClone/FindYourOnlysCloneTests/Adopt List/UI/Helpers/AdoptListViewController+TestHelpers.swift
@@ -21,14 +21,6 @@ extension AdoptListViewController {
         return cell as? AdoptListCell
     }
     
-    @discardableResult
-    func simulatePetImageViewIsNotVisible(at index: Int) -> AdoptListCell {
-        let cell = simulatePetImageViewIsVisible(at: index)!
-        let delegate = collectionView.delegate
-        delegate?.collectionView?(collectionView, didEndDisplaying: cell, forItemAt: IndexPath(item: index, section: petsSection))
-        return cell
-    }
-    
     func simulatePetImageViewIsNearVisible(at index: Int) {
         let dataSource = collectionView.prefetchDataSource
         dataSource?.collectionView(collectionView, prefetchItemsAt: [IndexPath(item: index, section: petsSection)])


### PR DESCRIPTION
…ndDisplaying` delegate method but cell resused. Since `didEndDisplaying` will be last invoked on refreshing  and cause first appearance cells can't received the binding results.